### PR TITLE
Fixed warning

### DIFF
--- a/optimize.lex
+++ b/optimize.lex
@@ -47,4 +47,4 @@ char *mychar;
 .      {       printf("%s", yytext);}
 %%
   int yywrap(void) {      return 1;  } 
-main(){yylex();}
+int main(){yylex();}


### PR DESCRIPTION
gcc -O2 -o optimize lex.yy.c
<stdin>:50:1: warning: return type defaults to 'int' [-Wimplicit-int]