### PR TITLE
Fix typo in missing bB env var error

### DIFF
--- a/2600basic.sh
+++ b/2600basic.sh
@@ -3,7 +3,7 @@
 # do some quick sanity checking...
 
 if [ ! "$bB" ] ; then
-  echo "### WARNING: the bB envionronment variable isn't set."
+  echo "### WARNING: the 'bB' environment variable isn't set."
 fi
 
 OSTYPE=$(uname -s)


### PR DESCRIPTION
"Environment" was misspelled in the error for the missing `$bB` environment variable.