### PR TITLE
Prefix `prerror` messages with `line %d: …`

### DIFF
--- a/statements.c
+++ b/statements.c
@@ -5533,7 +5533,7 @@ void drawscreen()
 
 void prerror(char *myerror)
 {
-    fprintf(stderr, "(%d): %s\n", line, myerror);
+    fprintf(stderr, "line %d: %s\n", line, myerror);
 }
 
 int printimmed(char *value)


### PR DESCRIPTION
When viewing compiler output with a single error message, it's not immediately clear that the number in parentheses is a source file line number as the formatting suggests it's a compiler error number.

Example output:
```
Verifying compiler files exist...
Verifying file permissions...
Found dasm version: DASM 2.20.15-SNAPSHOT
Starting build of fatari.bas

batari Basic v1.6-SNAPSHOT (c)2021
(191): invalid console switch/controller reference

Compilation failed.

Exit code: 1
Cleaning up files generated during compilation...
```

Confusing line:
```
(191): invalid console switch/controller reference
```

After this change:
```
line 191: invalid console switch/controller reference
```
