### PR TITLE
Fix Sublime project file, .gitignore for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # Prerequisites
 *.d
 
+# System files
+.DS_Store
+
 # Object files
 *.o
 *.ko
@@ -16,6 +19,10 @@
 # Precompiled Headers
 *.gch
 *.pch
+
+# IDE Files / Folders
+*.sublime-workspace
+.vscode
 
 # Libraries
 *.lib

--- a/extras/batari-Basic.sublime-project
+++ b/extras/batari-Basic.sublime-project
@@ -20,10 +20,7 @@
 			[
 				".vscode"
 			],
-			"path": "/Users/thinkyhead/Projects/Retro/batari-Basic"
-		},
-		{
-			"path": "/Users/thinkyhead/Projects/Retro/bAtariBasic/bB/source"
+			"path": ".."
 		}
 	],
 	"settings":


### PR DESCRIPTION
- Fix bad path in Sublime project file.
- Ignore `.DS_Store` and Sublime workspace files.